### PR TITLE
Allow TrustSet LimitAmount zero values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fireblocks-xrp-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fireblocks-xrp-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@fireblocks/ts-sdk": "^10.1.0",
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "lodash.isequal": "^4.5.0",
+        "ripple-binary-codec": "^2.6.0",
         "swagger-autogen": "^2.23.7",
         "swagger-ui-express": "^5.0.1",
         "xrpl": "^4.3.0"
@@ -4641,9 +4642,9 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.4.1.tgz",
-      "integrity": "sha512-ABwQnWE1WBOvya9WIJ/KiogdsulOw5X8IrIZ3wW0Ec1hiWUNitNuI9LhN9XwHhNFuuvZyRAr+SzgFTBTCTfxFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.6.0.tgz",
+      "integrity": "sha512-OJBRxjjalO7SrIwydHhcC9wOFLoeKcawoqSEfGZilAtXROYTWHx5kTly2VcUMmMMSEYIh1+yEstBtLBObNjeKQ==",
       "license": "ISC",
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "lodash.isequal": "^4.5.0",
+    "ripple-binary-codec": "^2.6.0",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.1",
     "xrpl": "^4.3.0"

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -186,7 +186,8 @@ export class TokenService {
       throw new ValidationError("InvalidHolder", `Invalid address: ${address}`);
     }
 
-    validateAmount("LimitAmount", limitAmount);
+    // Allow zero values for TrustSet (required to delete trustlines)
+    validateAmount("LimitAmount", limitAmount, true);
 
     // Validate qualityIn / qualityOut if provided
     if (qualityIn !== undefined || qualityOut !== undefined) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -286,9 +286,10 @@ export function validateHash256(name: string, value: string) {
  *
  * @param name - Name of the amount field (used in error messages)
  * @param amt - The amount to validate (string for XRP, object for token)
+ * @param allowZero - Optional flag to allow zero values (e.g., for TrustSet to delete trustlines)
  * @throws {ValidationError} If the amount is invalid
  */
-export const validateAmount = (name: string, amt: Amount): void => {
+export const validateAmount = (name: string, amt: Amount, allowZero: boolean = false): void => {
   // Check for null/undefined
   if (amt === null || amt === undefined) {
     throw new ValidationError(
@@ -385,11 +386,18 @@ export const validateAmount = (name: string, amt: Amount): void => {
       );
     }
 
-    // Validate value is positive
-    if (parseFloat(value) <= 0) {
+    // Validate value is positive (unless allowZero is true, which allows 0 for TrustSet deletion)
+    const valueNum = parseFloat(value);
+    if (!allowZero && valueNum <= 0) {
       throw new ValidationError(
         "InvalidAmount",
         `${name} must be a positive amount`
+      );
+    }
+    if (allowZero && valueNum < 0) {
+      throw new ValidationError(
+        "InvalidAmount",
+        `${name} cannot be negative`
       );
     }
   } else {

--- a/tests/services/TokenService.test.ts
+++ b/tests/services/TokenService.test.ts
@@ -299,6 +299,31 @@ describe("TokenService", () => {
         )
       ).toThrow(ValidationError);
     });
+
+    it("allows zero value limitAmount for TrustSet (to delete trustline)", () => {
+      mockIsValidAddress.mockReturnValue(true);
+      mockValidateAmount.mockReturnValue(undefined);
+      const zeroLimitAmount = {
+        currency: "USD",
+        issuer: "rIssuer",
+        value: "0",
+      };
+      const tx = service.createTrustSetTx(
+        baseArgs.address,
+        baseArgs.fee,
+        baseArgs.sequence,
+        zeroLimitAmount,
+        baseArgs.lastLedgerSequence
+      );
+      expect(tx.TransactionType).toBe("TrustSet");
+      expect(tx.LimitAmount).toEqual(zeroLimitAmount);
+      // Verify validateAmount was called with allowZero=true (third parameter)
+      expect(mockValidateAmount).toHaveBeenCalledWith(
+        "LimitAmount",
+        zeroLimitAmount,
+        true
+      );
+    });
   });
 
   // ---- createAccountSetTx ----

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -235,6 +235,39 @@ describe("Utils", () => {
         })
       ).toThrow(ValidationError);
       expect(() => validateAmount("Amount", "0")).toThrow(ValidationError);
+      // Zero should throw by default
+      expect(() =>
+        validateAmount("Amount", {
+          currency: "USD",
+          issuer: "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+          value: "0",
+        })
+      ).toThrow(ValidationError);
+    });
+    it("allows zero amount when allowZero is true", () => {
+      expect(() =>
+        validateAmount(
+          "Amount",
+          {
+            currency: "USD",
+            issuer: "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+            value: "0",
+          },
+          true
+        )
+      ).not.toThrow();
+      // Negative should still throw even with allowZero
+      expect(() =>
+        validateAmount(
+          "Amount",
+          {
+            currency: "USD",
+            issuer: "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+            value: "-1",
+          },
+          true
+        )
+      ).toThrow(ValidationError);
     });
     it("throws ValidationError for invalid amount object", () => {
       expect(() =>


### PR DESCRIPTION
## Summary
- Allow `TrustSet` `LimitAmount.value` to be `0` (used to delete trustlines) while still rejecting negative values.
- Add unit tests covering `allowZero` behavior and TrustSet zero limit validation.

## Test plan
- `npm test`
- `npm run build`