### PR TITLE
Add deliverMin support to cross-currency payments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fireblocks-xrp-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fireblocks-xrp-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@fireblocks/ts-sdk": "^10.1.0",
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "lodash.isequal": "^4.5.0",
+        "ripple-binary-codec": "^2.6.0",
         "swagger-autogen": "^2.23.7",
         "swagger-ui-express": "^5.0.1",
         "xrpl": "^4.3.0"
@@ -4641,9 +4642,9 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.4.1.tgz",
-      "integrity": "sha512-ABwQnWE1WBOvya9WIJ/KiogdsulOw5X8IrIZ3wW0Ec1hiWUNitNuI9LhN9XwHhNFuuvZyRAr+SzgFTBTCTfxFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.6.0.tgz",
+      "integrity": "sha512-OJBRxjjalO7SrIwydHhcC9wOFLoeKcawoqSEfGZilAtXROYTWHx5kTly2VcUMmMMSEYIh1+yEstBtLBObNjeKQ==",
       "license": "ISC",
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "lodash.isequal": "^4.5.0",
+    "ripple-binary-codec": "^2.6.0",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.1",
     "xrpl": "^4.3.0"

--- a/src/FireblocksXrpSdk.ts
+++ b/src/FireblocksXrpSdk.ts
@@ -183,6 +183,7 @@ export class FireblocksXrpSdk extends Wallet {
    * @param destination - destination address
    * @param amount - Amount to send
    * @param sendMax - Amount to send max
+   * @param deliverMin - optional, minimum amount to deliver (requires tfPartialPayment when used with sendMax)
    * @param flags - optional, flags for the transaction (common transaction flags)
    * @param invoiceId - optional, invoice ID for the transaction
    * @param destinationTag - optional, destination tag for the transaction
@@ -195,6 +196,7 @@ export class FireblocksXrpSdk extends Wallet {
     destination,
     amount,
     sendMax,
+    deliverMin,
     flags,
     invoiceId,
     destinationTag,
@@ -214,6 +216,7 @@ export class FireblocksXrpSdk extends Wallet {
         sequence,
         lastLedgerSequence,
         sendMax,
+        deliverMin,
         paths,
         flags,
         memos,

--- a/src/services/DexService.ts
+++ b/src/services/DexService.ts
@@ -4,6 +4,7 @@ import {
   Memo,
   OfferCancel,
   Payment,
+  PaymentFlags,
   Path,
   CredentialCreate,
   isValidAddress,
@@ -125,6 +126,7 @@ export class DexService {
    * @param sequence - The account sequence number
    * @param lastLedgerSequence - The last ledger sequence where this transaction is valid
    * @param sendMax - The maximum amount to send (for partial payments)
+   * @param deliverMin - Optional minimum amount to deliver (requires tfPartialPayment when used)
    * @param paths - Optional payment paths to use
    * @param flags - Optional flags for the Payment transaction
    * @param memos - Optional memos to attach to the transaction
@@ -141,6 +143,7 @@ export class DexService {
     sequence: number,
     lastLedgerSequence: number,
     sendMax?: Amount,
+    deliverMin?: Amount,
     paths?: Path[],
     flags?: IPaymentFlags,
     memos?: Memo[],
@@ -148,6 +151,8 @@ export class DexService {
     invoiceId?: string
   ): Payment => {
     try {
+      const { tfPartialPayment } = PaymentFlags;
+
       // Validate destination address
       if (!destination || typeof destination !== "string") {
         throw new ValidationError(
@@ -160,6 +165,9 @@ export class DexService {
       validateAmount("amount", amount);
       if (sendMax) {
         validateAmount("sendMax", sendMax);
+      }
+      if (deliverMin !== undefined) {
+        validateAmount("deliverMin", deliverMin);
       }
 
       // Validate destinationTag if provided
@@ -198,6 +206,18 @@ export class DexService {
         );
       }
 
+      // Ensure partial flag when using SendMax or DeliverMin
+      const wantsPartial = Boolean((combinedFlags ?? 0) & tfPartialPayment);
+      if (
+        !wantsPartial &&
+        (sendMax !== undefined || deliverMin !== undefined)
+      ) {
+        throw new ValidationError(
+          "InvalidFlags",
+          "SendMax or DeliverMin requires the tfPartialPayment flag."
+        );
+      }
+
       // Build and return transaction
       const tx: Payment = {
         TransactionType: "Payment",
@@ -208,6 +228,7 @@ export class DexService {
         Sequence: sequence,
         LastLedgerSequence: lastLedgerSequence,
         ...(sendMax !== undefined && { SendMax: sendMax }),
+        ...(deliverMin !== undefined && { DeliverMin: deliverMin }),
         ...(paths?.length ? { Paths: paths } : {}),
         ...(combinedFlags !== undefined && { Flags: combinedFlags }),
         ...(validatedMemos && validatedMemos.length > 0

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -186,7 +186,8 @@ export class TokenService {
       throw new ValidationError("InvalidHolder", `Invalid address: ${address}`);
     }
 
-    validateAmount("LimitAmount", limitAmount);
+    // Allow zero values for TrustSet (required to delete trustlines)
+    validateAmount("LimitAmount", limitAmount, true);
 
     // Validate qualityIn / qualityOut if provided
     if (qualityIn !== undefined || qualityOut !== undefined) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -286,9 +286,10 @@ export function validateHash256(name: string, value: string) {
  *
  * @param name - Name of the amount field (used in error messages)
  * @param amt - The amount to validate (string for XRP, object for token)
+ * @param allowZero - Optional flag to allow zero values (e.g., for TrustSet to delete trustlines)
  * @throws {ValidationError} If the amount is invalid
  */
-export const validateAmount = (name: string, amt: Amount): void => {
+export const validateAmount = (name: string, amt: Amount, allowZero: boolean = false): void => {
   // Check for null/undefined
   if (amt === null || amt === undefined) {
     throw new ValidationError(
@@ -385,11 +386,18 @@ export const validateAmount = (name: string, amt: Amount): void => {
       );
     }
 
-    // Validate value is positive
-    if (parseFloat(value) <= 0) {
+    // Validate value is positive (unless allowZero is true, which allows 0 for TrustSet deletion)
+    const valueNum = parseFloat(value);
+    if (!allowZero && valueNum <= 0) {
       throw new ValidationError(
         "InvalidAmount",
         `${name} must be a positive amount`
+      );
+    }
+    if (allowZero && valueNum < 0) {
+      throw new ValidationError(
+        "InvalidAmount",
+        `${name} cannot be negative`
       );
     }
   } else {

--- a/tests/services/DexService.test.ts
+++ b/tests/services/DexService.test.ts
@@ -206,6 +206,7 @@ describe("DexService", () => {
       sequence: 1,
       lastLedgerSequence: 10,
       sendMax: { currency: "USD", issuer: "rIssuer", value: "150" } as Amount,
+      deliverMin: { currency: "EUR", issuer: "rIssuer2", value: "90" } as Amount,
       paths: [
         [{ account: "rSomeAccount", currency: "USD", issuer: "rIssuer" }],
       ] as Path[],
@@ -228,6 +229,7 @@ describe("DexService", () => {
         baseArgs.sequence,
         baseArgs.lastLedgerSequence,
         baseArgs.sendMax,
+        baseArgs.deliverMin,
         baseArgs.paths,
         baseArgs.flags,
         baseArgs.memos,
@@ -236,11 +238,67 @@ describe("DexService", () => {
       );
       expect(tx.TransactionType).toBe("Payment");
       expect(tx.SendMax).toEqual(baseArgs.sendMax);
+      expect(tx.DeliverMin).toEqual(baseArgs.deliverMin);
       expect(tx.Paths).toEqual(baseArgs.paths);
       expect(tx.Flags).toBe(0x00020000);
       expect(tx.Memos).toEqual(baseArgs.memos);
       expect(tx.DestinationTag).toBe(baseArgs.destinationTag);
       expect(tx.InvoiceID).toBe(baseArgs.invoiceId);
+    });
+
+    it("includes DeliverMin when deliverMin is provided", () => {
+      mockValidateAmount.mockReturnValue(undefined);
+      mockDerivePaymentFlags.mockReturnValue(0x00020000);
+
+      const tx = service.getCrossCurrencyPaymentUnsignedTx(
+        baseArgs.address,
+        baseArgs.destination,
+        baseArgs.amount,
+        baseArgs.fee,
+        baseArgs.sequence,
+        baseArgs.lastLedgerSequence,
+        baseArgs.sendMax,
+        baseArgs.deliverMin,
+        baseArgs.paths,
+        baseArgs.flags,
+        baseArgs.memos,
+        baseArgs.destinationTag,
+        baseArgs.invoiceId
+      );
+      expect(tx.DeliverMin).toEqual(baseArgs.deliverMin);
+    });
+
+    it("throws ValidationError when sendMax or deliverMin used without tfPartialPayment", () => {
+      mockValidateAmount.mockReturnValue(undefined);
+      mockDerivePaymentFlags.mockReturnValue(0); // no tfPartialPayment
+
+      expect(() =>
+        service.getCrossCurrencyPaymentUnsignedTx(
+          baseArgs.address,
+          baseArgs.destination,
+          baseArgs.amount,
+          baseArgs.fee,
+          baseArgs.sequence,
+          baseArgs.lastLedgerSequence,
+          baseArgs.sendMax,
+          undefined,
+          baseArgs.paths
+        )
+      ).toThrow(new ValidationError("InvalidFlags", "SendMax or DeliverMin requires the tfPartialPayment flag."));
+
+      expect(() =>
+        service.getCrossCurrencyPaymentUnsignedTx(
+          baseArgs.address,
+          baseArgs.destination,
+          baseArgs.amount,
+          baseArgs.fee,
+          baseArgs.sequence,
+          baseArgs.lastLedgerSequence,
+          undefined,
+          { currency: "EUR", issuer: "rI", value: "50" } as Amount,
+          baseArgs.paths
+        )
+      ).toThrow(new ValidationError("InvalidFlags", "SendMax or DeliverMin requires the tfPartialPayment flag."));
     });
 
     it("omits optional fields when not provided", () => {
@@ -256,6 +314,7 @@ describe("DexService", () => {
         baseArgs.lastLedgerSequence
       );
       expect(tx.SendMax).toBeUndefined();
+      expect(tx.DeliverMin).toBeUndefined();
       expect(tx.Paths).toBeUndefined();
       expect(tx.Flags).toBeUndefined();
       expect(tx.Memos).toBeUndefined();
@@ -303,7 +362,8 @@ describe("DexService", () => {
           baseArgs.fee,
           baseArgs.sequence,
           baseArgs.lastLedgerSequence,
-          baseArgs.sendMax
+          baseArgs.sendMax,
+          undefined // deliverMin
         )
       ).toThrow(ValidationError);
     });
@@ -321,6 +381,7 @@ describe("DexService", () => {
           undefined,
           undefined,
           undefined,
+          undefined,
           -5
         )
       ).toThrow(ValidationError);
@@ -333,6 +394,7 @@ describe("DexService", () => {
           baseArgs.fee,
           baseArgs.sequence,
           baseArgs.lastLedgerSequence,
+          undefined,
           undefined,
           undefined,
           undefined,
@@ -356,6 +418,7 @@ describe("DexService", () => {
           baseArgs.fee,
           baseArgs.sequence,
           baseArgs.lastLedgerSequence,
+          undefined,
           undefined,
           undefined,
           baseArgs.flags

--- a/tests/services/TokenService.test.ts
+++ b/tests/services/TokenService.test.ts
@@ -299,6 +299,31 @@ describe("TokenService", () => {
         )
       ).toThrow(ValidationError);
     });
+
+    it("allows zero value limitAmount for TrustSet (to delete trustline)", () => {
+      mockIsValidAddress.mockReturnValue(true);
+      mockValidateAmount.mockReturnValue(undefined);
+      const zeroLimitAmount = {
+        currency: "USD",
+        issuer: "rIssuer",
+        value: "0",
+      };
+      const tx = service.createTrustSetTx(
+        baseArgs.address,
+        baseArgs.fee,
+        baseArgs.sequence,
+        zeroLimitAmount,
+        baseArgs.lastLedgerSequence
+      );
+      expect(tx.TransactionType).toBe("TrustSet");
+      expect(tx.LimitAmount).toEqual(zeroLimitAmount);
+      // Verify validateAmount was called with allowZero=true (third parameter)
+      expect(mockValidateAmount).toHaveBeenCalledWith(
+        "LimitAmount",
+        zeroLimitAmount,
+        true
+      );
+    });
   });
 
   // ---- createAccountSetTx ----

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -235,6 +235,39 @@ describe("Utils", () => {
         })
       ).toThrow(ValidationError);
       expect(() => validateAmount("Amount", "0")).toThrow(ValidationError);
+      // Zero should throw by default
+      expect(() =>
+        validateAmount("Amount", {
+          currency: "USD",
+          issuer: "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+          value: "0",
+        })
+      ).toThrow(ValidationError);
+    });
+    it("allows zero amount when allowZero is true", () => {
+      expect(() =>
+        validateAmount(
+          "Amount",
+          {
+            currency: "USD",
+            issuer: "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+            value: "0",
+          },
+          true
+        )
+      ).not.toThrow();
+      // Negative should still throw even with allowZero
+      expect(() =>
+        validateAmount(
+          "Amount",
+          {
+            currency: "USD",
+            issuer: "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+            value: "-1",
+          },
+          true
+        )
+      ).toThrow(ValidationError);
     });
     it("throws ValidationError for invalid amount object", () => {
       expect(() =>


### PR DESCRIPTION
Adds optional `deliverMin` to cross-currency payments so it is passed through to the XRPL Payment tx (previously only tokenTransfer supported it).

- FireblocksXrpSdk: destructure and pass `deliverMin` into DexService
- DexService: accept `deliverMin`, validate, require `tfPartialPayment` when used, set `DeliverMin` on Payment
- Tests: cover deliverMin and tfPartialPayment requirement